### PR TITLE
Juniper SAAS support: expose fullname field

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -486,6 +486,15 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         default=False,
         scope=Scope.settings
     )
+
+    ask_to_send_fullname = Boolean(
+        display_name=_("Request user's full name"),
+        # Translators: This is used to request the user's full name for a third party service.
+        help=_("Select True to request the user's full name."),
+        default=False,
+        scope=Scope.settings,
+    )
+
     enable_processors = Boolean(
         display_name=_("Send extra parameters"),
         help=_("Select True to send the extra parameters, which might contain Personally Identifiable Information. "
@@ -504,7 +513,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # Other parameters
         'custom_parameters', 'launch_target', 'button_text', 'inline_height', 'modal_height',
         'modal_width', 'has_score', 'weight', 'hide_launch', 'accept_grades_past_due',
-        'ask_to_send_username', 'ask_to_send_email', 'enable_processors',
+        'ask_to_send_username', 'ask_to_send_email', 'ask_to_send_fullname', 'enable_processors',
     )
 
     # Author view
@@ -578,15 +587,15 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     @property
     def editable_fields(self):
         """
-        Returns editable fields which may/may not contain 'ask_to_send_username' and
-        'ask_to_send_email' fields depending on the configuration service.
+        Returns editable fields which may/may not contain 'ask_to_send_username',
+        'ask_to_send_email' and 'ask_to_send_fullname' fields depending on the configuration service.
         """
         editable_fields = self.editable_field_names
         # update the editable fields if this XBlock is configured to not to allow the
-        # editing of 'ask_to_send_username' and 'ask_to_send_email'.
+        # editing of 'ask_to_send_username', 'ask_to_send_email' and ask_to_send_fullname.
         config_service = self.runtime.service(self, 'lti-configuration')
         if config_service:
-            is_already_sharing_learner_info = self.ask_to_send_email or self.ask_to_send_username
+            is_already_sharing_learner_info = self.ask_to_send_email or self.ask_to_send_username or self.ask_to_send_fullname
             if not config_service.configuration.lti_access_to_learners_editable(
                     self.course_id,
                     is_already_sharing_learner_info,
@@ -594,7 +603,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 editable_fields = tuple(
                     field
                     for field in self.editable_field_names
-                    if field not in ('ask_to_send_username', 'ask_to_send_email')
+                    if field not in ('ask_to_send_username', 'ask_to_send_email', 'ask_to_send_fullname')
                 )
 
         # Hide LTI 1.3 fields if flag is disabled
@@ -865,12 +874,14 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'user_email': None,
             'user_username': None,
             'user_language': None,
+            'user_fullname': None,
         }
 
         if callable(self.runtime.get_real_user):
             real_user_object = self.runtime.get_real_user(self.runtime.anonymous_student_id)
             user_data['user_email'] = getattr(real_user_object, "email", "")
             user_data['user_username'] = getattr(real_user_object, "username", "")
+            user_data['user_fullname'] = getattr(getattr(real_user_object, "profile", {}), "name", "")
             user_preferences = getattr(real_user_object, "preferences", None)
 
             if user_preferences is not None:


### PR DESCRIPTION
This PR is related to the changes made in this [branch](https://github.com/eduNEXT/xblock-lti-consumer/commit/028076fc7a2eb7549049d7a20d96ccb361b49346) 
Those changes were applied to master.

NOTE: these changes were cherry picked, except the ones made in the `lti.py` file, that file was removed so I moved the changes from lti.py `method get_signed_lti_parameters` to lti_xblock.py `method extract_real_user_data`